### PR TITLE
Pin version of nf-validation and nf-iridanext #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2024/02/23
+
+### `Changed`
+
+- Pinned Nextflow plugins to specific versions (nf-validation@1.1.3 and nf-iridanext@0.2.0)
+
 ## 2.0.0 - 2024/02/14
 
 ### `Added`

--- a/nextflow.config
+++ b/nextflow.config
@@ -165,8 +165,8 @@ singularity.registry = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation' // Validation of pipeline parameters and creation of an input channel from a sample sheet
-    id 'nf-iridanext' // Output for IRIDA Next
+    id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-iridanext@0.2.0' // Output for IRIDA Next
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
@@ -208,7 +208,7 @@ manifest {
     description     = """SNVPhyl Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '2.0.0'
+    version         = '2.0.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
<!--
# phac-nml/snvphylnfc pull request

Many thanks for contributing to phac-nml/snvphylnfc!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/snvphylnfc/tree/main/.github/CONTRIBUTING.md)
-->

PR in response to the following issue:
Pin version of nf-validation and nf-iridanext #14

The nextflow.config file has been updated to pin specific versions for the following plugins:
- nf-validation@1.1.3
- nf-iridanext@0.2.0

Pinning specific versions of the Nextflow plugins will circumvent breaking changes associated with the recent upgrade of the nf-validation plugin from 1.1.3 to 2.0.0. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

