### PR TITLE
Adding the Ability to Use a Compressed Reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Added`
+
+- Support for compressed (GZIP-formatted) reference files.
+
 ## 2.0.1 - 2024/02/23
 
 ### `Changed`

--- a/modules/local/findrepeats/main.nf
+++ b/modules/local/findrepeats/main.nf
@@ -20,8 +20,14 @@ process FIND_REPEATS {
     path("versions.yml"),             emit: versions
 
     script:
+    // Decompress reference if necessary:
+    def decompress_refgenome = refgenome.toString().endsWith(".gz") ? "gunzip -q -f $refgenome" : ""
+    def refgenome_path = refgenome.toString().endsWith(".gz") ? refgenome.toString().split('.gz')[0] : refgenome
+
     """
-    find-repeats.pl ${refgenome} --min-length ${params.min_repeat_length} --min-pid ${params.min_repeat_pid} > invalid_positions.bed
+    $decompress_refgenome
+
+    find-repeats.pl ${refgenome_path} --min-length ${params.min_repeat_length} --min-pid ${params.min_repeat_pid} > invalid_positions.bed
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/freebayes/main.nf
+++ b/modules/local/freebayes/main.nf
@@ -21,9 +21,15 @@ process FREEBAYES {
     path("versions.yml"),                                emit: versions
 
     script:
+    // Decompress reference if necessary:
+    def decompress_refgenome = refgenome.toString().endsWith(".gz") ? "gunzip -q -f $refgenome" : ""
+    def refgenome_path = refgenome.toString().endsWith(".gz") ? refgenome.toString().split('.gz')[0] : refgenome
+
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    freebayes --bam ${sorted_bams} --ploidy 1 --fasta-reference ${refgenome} --vcf ${prefix}_freebayes.vcf
+    $decompress_refgenome
+
+    freebayes --bam ${sorted_bams} --ploidy 1 --fasta-reference ${refgenome_path} --vcf ${prefix}_freebayes.vcf
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/indexing/main.nf
+++ b/modules/local/indexing/main.nf
@@ -22,10 +22,15 @@ process INDEXING {
     path("versions.yml"), emit: versions
 
     script:
+    // Decompress reference if necessary:
+    def decompress_refgenome = refgenome.toString().endsWith(".gz") ? "gunzip -q -f $refgenome" : ""
+    def refgenome_path = refgenome.toString().endsWith(".gz") ? refgenome.toString().split('.gz')[0] : refgenome
+
     """
-    REF_BASENAME=\$(basename ${refgenome} .fasta)
-    smalt index -k 13 -s 6 \${REF_BASENAME} ${refgenome}
-    samtools faidx ${refgenome}
+    $decompress_refgenome
+
+    smalt index -k 13 -s 6 reference ${refgenome_path}
+    samtools faidx ${refgenome_path}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/mpileup/main.nf
+++ b/modules/local/mpileup/main.nf
@@ -21,9 +21,15 @@ process MPILEUP {
     path("versions.yml"),                                 emit: versions
 
     script:
+    // Decompress reference if necessary:
+    def decompress_refgenome = refgenome.toString().endsWith(".gz") ? "gunzip -q -f $refgenome" : ""
+    def refgenome_path = refgenome.toString().endsWith(".gz") ? refgenome.toString().split('.gz')[0] : refgenome
+
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    bcftools mpileup --threads ${task.cpus} --fasta-ref ${refgenome} -A -B -C 0 -d 1024 -q 0 -Q 0 --output-type z -I --output ${prefix}_mpileup.vcf.gz ${sorted_bams}
+    $decompress_refgenome
+
+    bcftools mpileup --threads ${task.cpus} --fasta-ref ${refgenome_path} -A -B -C 0 -d 1024 -q 0 -Q 0 --output-type z -I --output ${prefix}_mpileup.vcf.gz ${sorted_bams}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -54,7 +54,7 @@
                     "type": "string",
                     "description": "The file path to the FASTA-format reference genome.",
                     "fa_icon": "fas fa-file",
-                    "pattern": "^\\S+\\.(fa|fas|fasta)$",
+                    "pattern": "^\\S+\\.f(ast)?a(\\.gz)?$",
                     "format": "file-path"
                 }
             },

--- a/tests/workflows/snvphylnfc.nf.test
+++ b/tests/workflows/snvphylnfc.nf.test
@@ -190,4 +190,74 @@ nextflow_workflow {
 
     }
 
+    test("compressed reference") {
+
+        when {
+            params {
+                input = "https://raw.githubusercontent.com/phac-nml/snvphylnfc/dev/assets/samplesheet.csv"
+                refgenome = "https://github.com/phac-nml/snvphylnfc/raw/dev/tests/data/reference.fasta.gz"
+                outdir = "results"
+            }
+            workflow {}
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            def lines = []
+
+            // check FILTER_STATS output
+            lines = path("$launchDir/results/filter/filterStats.txt").readLines()
+
+            assert lines.contains("Number of sites used to generate phylogeny: 2")
+            assert lines.contains("Total number of sites identified: 2")
+            assert lines.contains("Number of sites filtered: 0")
+
+            // check filtered density files:
+            assert path("$launchDir/results/consolidate/SAMPLE1_filtered_density.txt").exists()
+            assert path("$launchDir/results/consolidate/SAMPLE2_filtered_density.txt").exists()
+            assert path("$launchDir/results/consolidate/SAMPLE3_filtered_density.txt").exists()
+
+            lines = path("$launchDir/results/cat/cat_invalid_positions.txt").readLines()
+            assert lines.contains("#Calculation and writing of high density regions has completed.")
+
+            // check PHYML output
+            lines = path("$launchDir/results/phyml/phylogeneticTreeStats.txt").readLines()
+
+            assert lines.contains(". Model of nucleotides substitution: \tGTR")
+            assert lines.contains("  - f(A)=  0.75000")
+            assert lines.contains("  - f(C)=  0.12500")
+            assert lines.contains("  - f(G)=  0.01000")
+            assert lines.contains("  - f(T)=  0.12500")
+
+            lines = path("$launchDir/results/phyml/phylogeneticTree.newick").readLines()
+
+            assert lines.join("\n").contains("SAMPLE1")
+            assert lines.join("\n").contains("SAMPLE2")
+            assert lines.join("\n").contains("SAMPLE3")
+
+            // check MAKE_SNV output
+            lines = path("$launchDir/results/make/snvMatrix.tsv").readLines()
+
+            assert lines[0] == "strain\tSAMPLE2\tSAMPLE3\tSAMPLE1\treference\t"
+            assert lines.contains("SAMPLE1\t1\t1\t0\t0\t")
+            assert lines.contains("SAMPLE2\t0\t2\t1\t1\t")
+            assert lines.contains("SAMPLE3\t2\t0\t1\t1\t")
+
+            // check IRIDA Next JSON file
+            lines = path("$launchDir/results/iridanext.output.json.gz").linesGzip.join("\n")
+            
+            assert lines.contains("\"path\": \"make/snvMatrix.tsv\"")
+            assert lines.contains("\"path\": \"filter/filterStats.txt\"")
+            assert lines.contains("\"path\": \"phyml/phylogeneticTreeStats.txt\"")
+            assert lines.contains("\"path\": \"phyml/phylogeneticTree.newick\"")
+            assert lines.contains("\"path\": \"vcf2snv/snvTable.tsv\"")
+            assert lines.contains("\"path\": \"vcf2snv/vcf2core.tsv\"")
+            assert lines.contains("\"path\": \"vcf2snv/snvAlignment.phy\"")
+            assert lines.contains("\"path\": \"verifying/mappingQuality.txt\"")
+        }
+
+    }
+
 }


### PR DESCRIPTION
This PR adds the ability to provide a compressed reference (`*.fasta.gz*`) either through the samplesheet and sample ID selection (`--reference_sample_id`) or by directly providing the reference (`--refgenome`). These two methods are handled the same internally after the file path is acquired.