### PR TITLE
Change container registry and python version for arborview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.1]
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.1] - 2024/08/20
+## [2.1.1] - 2024/08/21
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `Changed`
+
+- Container registry for aborview switched from docker.io to quay.io/biocontainers (python:3.11.6 to python:3.12)
+
 ## 2.1.0 - 2024/07/09
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.1]
+## [2.1.1] - 2024/08/20
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Container registry for aborview switched from docker.io to quay.io/biocontainers (python:3.11.6 to python:3.12)
 
-## 2.1.0 - 2024/07/09
+## [2.1.0] - 2024/07/09
 
 ### `Added`
 
 - Support for including contextual metadata in the input samplesheet: See [PR 22](https://github.com/phac-nml/snvphylnfc/pull/22)
 - ArborView HTML app functionality for viewing dendograms with contextual metadata: See [PR 22](https://github.com/phac-nml/snvphylnfc/pull/22)
 
-## 2.0.2 - 2024/05/21
+## [2.0.2] - 2024/05/21
 
 ### `Added`
 
 - Support for compressed (GZIP-formatted) reference files.
 
-## 2.0.1 - 2024/02/23
+## [2.0.1] - 2024/02/23
 
 ### `Changed`
 
 - Pinned Nextflow plugins to specific versions (nf-validation@1.1.3 and nf-iridanext@0.2.0)
 
-## 2.0.0 - 2024/02/14
+## [2.0.0] - 2024/02/14
 
 ### `Added`
 
@@ -44,3 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 ### `Dependencies`
+
+[2.1.1]: https://github.com/phac-nml/snvphylnfc/releases/tag/2.1.1
+[2.1.0]: https://github.com/phac-nml/snvphylnfc/releases/tag/2.1.0
+[2.0.2]: https://github.com/phac-nml/snvphylnfc/releases/tag/2.0.2
+[2.0.1]: https://github.com/phac-nml/snvphylnfc/releases/tag/2.0.1
+[2.0.0]: https://github.com/phac-nml/snvphylnfc/releases/tag/2.0.0

--- a/modules/local/arborview.nf
+++ b/modules/local/arborview.nf
@@ -4,7 +4,7 @@ process ARBOR_VIEW {
     stageInMode 'copy' // Need to copy in arbor view html
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    "biocontainers/python:3.12" :
+    "https://depot.galaxyproject.org/singularity/python%3A3.12" :
     "biocontainers/python:3.12" }"
 
     input:

--- a/modules/local/arborview.nf
+++ b/modules/local/arborview.nf
@@ -4,8 +4,8 @@ process ARBOR_VIEW {
     stageInMode 'copy' // Need to copy in arbor view html
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    "docker.io/python:3.11.6" :
-    "docker.io/python:3.11.6" }"
+    "biocontainers/python:3.12" :
+    "biocontainers/python:3.12" }"
 
     input:
     tuple path(tree), path(metadata)

--- a/modules/local/phyml/main.nf
+++ b/modules/local/phyml/main.nf
@@ -9,7 +9,7 @@ Please refer to the README for more information.
 */
 process PHYML {
     label 'process_low'
-    container = "quay.io/biocontainers/phyml:3.3.20211231--hee9e358_0"
+    container = "biocontainers/phyml:3.3.20211231--hee9e358_0"
 
     input:
     path(snvAlignment_phy)

--- a/nextflow.config
+++ b/nextflow.config
@@ -217,7 +217,7 @@ manifest {
     description     = """SNVPhyl Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '2.1.0'
+    version         = '2.1.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
**Summary:** In short, we swapped out the `docker.io` registry for `quay.io`.

**Rationale for the change:** This aligns the pipeline more closely with `nf-core` pipeline [requirements](https://nf-co.re/docs/guidelines/pipelines/requirements/docker) which is to use `biocontainers` where possible. An aditional benefit of this change is that if the pipeline is being run somewhere where a local registry is required for the docker containers this can be easily modified in the parameter `docker.registry`  `nextflow.config` [file](https://github.com/phac-nml/snvphylnfc/blob/cb47436c0eada0a0466e0903bec5d70ffcc6622f/nextflow.config#L171).

**Additional Information:** The change was only required within the `ARBOR_VIEW` module.  The container `python:3.11.6` was changed for `python:3.12` as no `python:3.11.6` was available as a [biocontainer](https://biocontainers.pro/tools/python). 

## PR checklist
- [x] Ensure output not impacted (`nf-test test`)
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
