### PR TITLE
Add/max samples

### DIFF
--- a/conf/iridanext.config
+++ b/conf/iridanext.config
@@ -15,7 +15,8 @@ iridanext {
                 "**/make/snvMatrix.tsv",
                 "**/vcf2snv/snvTable.tsv",
                 "**/vcf2snv/vcf2core.tsv",
-                "**/pipeline_info/software_versions.yml"]
+                "**/pipeline_info/software_versions.yml",
+                "**/error/max_samples_exceeded.error.txt"]
         }
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -15,6 +15,31 @@ nextflow.enable.dsl = 2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
+process MAX_SAMPLES_CHECK {
+    tag "max_samples_error"
+    publishDir "${params.outdir}/error"
+
+    input:
+    val sample_count // number of samples provided to mikrokondo
+
+    output:
+    path output_file_path, emit: failure_report
+
+    exec:
+    def output_file =  "max_samples_exceeded.error.txt"
+    output_file_path = task.workDir.resolve(output_file)
+    file_out = file(output_file_path)
+    file_out.text = """   
+    ${sample_count} samples were selected, which exceeds the maximum number of samples: ${params.max_samples}
+    Please reduce samples to ${params.max_samples}.
+    Pipeline maximum sample count threshold should only occur when running in IRIDA Next,
+    please submit an issue if you encounter it elsewhere. 
+    
+    If running from command-line make sure that --max_samples 0
+    """.stripIndent().trim()
+}
+
+include { SNVPHYL } from './workflows/snvphylnfc'
 include { validateParameters; paramsHelp; paramsSummaryLog; fromSamplesheet } from 'plugin/nf-validation'
 
 // Print help message if needed
@@ -35,18 +60,26 @@ WorkflowMain.initialise(workflow, params, log)
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    NAMED WORKFLOW FOR PIPELINE
+    MAX_SAMPLES CHECK
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Dont bother checking the number of lines in the samples if max_samples == 0
+    as we will not do anything with the limit. 
 */
 
-include { SNVPHYL } from './workflows/snvphylnfc'
+    def number_of_samples = file(params.input).readLines().size() - 1 // Remove 1 for header
+    def unlimited_samples = (params.max_samples == 0) ? true : false
 
 //
 // WORKFLOW: Run main phac-nml/snvphylnfc analysis pipeline
 //
-workflow PHACNML_SNVPHYL {
-    SNVPHYL ()
-}
+   
+    workflow PHACNML_SNVPHYL {
+    if( unlimited_samples || number_of_samples <= params.max_samples){
+        SNVPHYL ()
+    }else{
+        MAX_SAMPLES_CHECK(channel.value(number_of_samples))
+        log.info "Parameter --max_samples was set: See outdir/error/max_samples_exceeded.error.txt for more information."
+   }}
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     input                      = null
     refgenome                  = null
     reference_sample_id        = null
+    max_samples                = 0    // Only > 0 integers set a maximum number of samples (default is unlimited)
 
     // Metadata
     metadata_1_header = "metadata_1"
@@ -217,7 +218,7 @@ manifest {
     description     = """SNVPhyl Pipeline"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '2.3.1'
+    version         = '2.3.2'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -35,6 +35,13 @@
                     "fa_icon": "fas fa-envelope",
                     "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
                     "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
+                },
+                "max_samples": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Limit the number of samples run by pipeline",
+                    "minimum": 0,
+                    "hidden": true
                 }
             }
         },

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -1,0 +1,34 @@
+nextflow_pipeline {
+
+    name "Full Integration Tests for SNVPHYLNFC"
+    script "main.nf"
+
+    test("Test max_samples: fails due to limit") {
+    tag "fail_max_samples"
+
+        when {
+            params {
+                input = "$baseDir/assets/samplesheet.csv"
+                refgenome = "https://raw.githubusercontent.com/phac-nml/snvphylnfc/dev/assets/reference.fasta"
+                outdir = "results"
+                max_samples = 2
+            }
+        }
+
+        then {
+
+            // Check the error-log file
+            def max_sample_log = "$launchDir/results/error/max_samples_exceeded.error.txt"
+            assert file(max_sample_log).exists()
+            assert path(max_sample_log).readLines().contains("3 samples were selected, which exceeds the maximum number of samples: 2")
+
+            // Check IRIDA Next JSON output
+            assert path("$launchDir/results/iridanext.output.json.gz").exists()
+            def lines = []
+            lines = path("$launchDir/results/iridanext.output.json.gz").linesGzip.join("\n")
+            assert lines.contains("\"path\": \"error/max_samples_exceeded.error.txt\"")
+        }
+
+    }
+
+}

--- a/tests/workflows/snvphylnfc.nf.test
+++ b/tests/workflows/snvphylnfc.nf.test
@@ -260,4 +260,35 @@ nextflow_workflow {
 
     }
 
+    test("Test max_samples: fails due to limit") {
+    tag "fail_max_samples"
+
+        when {
+            params {
+                input = "$baseDir/assets/samplesheet.csv"
+                refgenome = "https://raw.githubusercontent.com/phac-nml/snvphylnfc/dev/assets/reference.fasta"
+                outdir = "results"
+                max_samples = 2
+            }
+            workflow {}
+        }
+
+        then {
+
+            // Check the error-log file
+            def max_sample_log = "$launchDir/results/error/max_samples_exceeded.error.txt"
+            assert file(max_sample_log).exists()
+            assert path(max_sample_log).readLines().contains("3 samples were selected, which exceeds the maximum number of samples: 2")
+
+            // Check IRIDA Next JSON output
+            assert path("$launchDir/results/iridanext.output.json").exists()
+
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global.path
+
+            assert iridanext_global == ['error/max_samples_exceeded.error.txt']
+        }
+
+    }
+
 }


### PR DESCRIPTION
### STRY0018776: Limit Sample Submission

### Description:
We want there to be an ability to enforce a maximum number of samples that can be submitted in a single run for SNVPhylnfc.

### Criteria

1. A new parameter is added to the SNVPhylnfc pipeline configuration for specifying the maximum number of samples allowed.
2. The parameter only accepts a single value (integer) as the maximum limit (e.g., max_samples=500).
    a. Therefore this parameter is not modifiable by end users above the single value (i.e. hidden)
    b. A description is included in the pipeline submission interface, explicitly stating the maximum number of samples allowed and instructs users to contact the administrator if they need to process more samples.
3. Submissions below or equal to the limit are processed successfully.

- [x] Add parameter
- [x] Add tests
- [ ] Change documentation (change the gitlab repo FAQ)
- [ ] Update Changelog
